### PR TITLE
feat: add keep-alive helper

### DIFF
--- a/src/keepAlive.tsx
+++ b/src/keepAlive.tsx
@@ -1,0 +1,66 @@
+import React, { ReactNode, useEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
+
+const cache = new Map<string, HTMLElement>()
+let root: HTMLElement | null = null
+
+function ensureRoot() {
+  if (typeof document === 'undefined') return null
+  if (!root) {
+    root = document.createElement('div')
+    root.id = '__keepalive__'
+    root.style.display = 'none'
+    document.body.appendChild(root)
+  }
+  return root
+}
+
+function Holder({ id, node }: { id: string; node: ReactNode }) {
+  const ref = useRef<HTMLSpanElement>(null)
+  const root = ensureRoot()
+  let el = cache.get(id)
+  if (!el && root) {
+    el = document.createElement('div')
+    root.appendChild(el)
+    cache.set(id, el)
+  }
+
+  useEffect(() => {
+    const container = cache.get(id)
+    if (ref.current && container && container.parentElement !== ref.current) {
+      ref.current.appendChild(container)
+    }
+    return () => {
+      const root = ensureRoot()
+      if (container && root && container.parentElement !== root) {
+        root.appendChild(container)
+      }
+    }
+  }, [id])
+
+  if (el) {
+    return <span ref={ref}>{createPortal(node, el)}</span>
+  }
+  return <>{node}</>
+}
+
+export function mount(node: ReactNode, id: string) {
+  if (typeof document === 'undefined') return node
+  return <Holder id={id} node={node} />
+}
+
+export function unmount(id: string) {
+  const root = ensureRoot()
+  const container = cache.get(id)
+  if (root && container && container.parentElement !== root) {
+    root.appendChild(container)
+  }
+}
+
+export function destroy(id: string) {
+  const container = cache.get(id)
+  if (container) {
+    container.remove()
+    cache.delete(id)
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { PersonalizedPrice } from './personalized/PersonalizedPrice'
 import { Countdown } from './personalized/Countdown'
+import { mount } from './keepAlive'
 import './style.css'
 
 type PromoState = {
@@ -50,7 +51,7 @@ export function App({ promoState }: { promoState?: PromoState }) {
       {/* CSR: precise countdown & CTA inside Shadow DOM-like wrapper */}
       <section style={{ marginTop: 16 }}>
         <strong>距离结束：</strong>{' '}
-        <Countdown endAt={initial.endAt} />
+        {mount(<Countdown endAt={initial.endAt} />, 'countdown')}
       </section>
 
       <section style={{ marginTop: 16 }}>
@@ -59,7 +60,7 @@ export function App({ promoState }: { promoState?: PromoState }) {
       </section>
 
       <section style={{ marginTop: 16 }}>
-        <PersonalizedPrice base={initial.basePrice} />
+        {mount(<PersonalizedPrice base={initial.basePrice} />, 'price')}
       </section>
 
       <footer>


### PR DESCRIPTION
## Summary
- add keepAlive utility for persistent components with mount/unmount/destroy APIs
- use keepAlive to wrap Countdown and PersonalizedPrice in App

## Testing
- `npm test` (fails: Missing script: "test")
- `node node_modules/vite/bin/vite.js build`
- `node node_modules/vite/bin/vite.js build --ssr src/entry-server.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68c022a6e8908320b3668bd98e9c5a33