### PR TITLE
feat: integrate Ant Design components

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "compression": "^1.7.4",
     "express": "^4.19.2",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "antd": "^5.17.3"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
+import ReactDOM from 'react-dom/client'
+import { Button, Skeleton } from 'antd'
+import 'antd/dist/reset.css'
 import { PersonalizedPrice } from './personalized/PersonalizedPrice'
 import { Countdown } from './personalized/Countdown'
 import './style.css'
@@ -36,10 +39,10 @@ export function App({ promoState }: { promoState?: PromoState }) {
 
       {/* SSR skeleton for image/title/price */}
       <div className="row" style={{ marginTop: 8 }}>
-        <div className="skeleton" style={{ width: 120, height: 120, borderRadius: 12 }} aria-hidden="true"></div>
+        <Skeleton.Button active style={{ width: 120, height: 120, borderRadius: 12 }} />
         <div style={{ flex: 1 }}>
-          <div className="skeleton" style={{ height: 16, width: '70%', marginBottom: 8 }} aria-hidden="true"></div>
-          <div className="skeleton" style={{ height: 16, width: '40%' }} aria-hidden="true"></div>
+          <Skeleton.Input active style={{ height: 16, width: '70%', marginBottom: 8 }} />
+          <Skeleton.Input active style={{ height: 16, width: '40%' }} />
           <div style={{ marginTop: 12 }}>
             {/* SSR shows safe base price; client may replace with personalized price */}
             <div className="price" id="price-ssr">¥{initial.basePrice}</div>
@@ -79,15 +82,21 @@ if (typeof window !== 'undefined' && 'customElements' in window) {
     connectedCallback() {
       if (!this._shadow) {
         this._shadow = this.attachShadow({ mode: 'open' });
-        const btn = document.createElement('button');
-        (btn as any).part = 'button';
-        btn.textContent = this.getAttribute('data-cta') || '立即购买';
-        btn.addEventListener('click', () => {
-          alert('下单成功（示例）');
-        });
-        const style = document.createElement('style');
-        style.textContent = `:host{display:inline-block} button{}`;
-        this._shadow.append(style, btn);
+        const mount = document.createElement('div');
+        this._shadow.append(mount);
+        const btnText = this.getAttribute('data-cta') || '立即购买';
+        const root = ReactDOM.createRoot(mount);
+        root.render(
+          <Button
+            type="primary"
+            {...({ part: 'button ant-btn ant-btn-primary' } as any)}
+            onClick={() => {
+              alert('下单成功（示例）');
+            }}
+          >
+            {btnText}
+          </Button>
+        );
       }
     }
   }

--- a/styles/critical.css
+++ b/styles/critical.css
@@ -2,12 +2,9 @@
 body { margin: 0; background: #fafafa; color: var(--text); }
 .container { max-width: 760px; margin: 40px auto; background: white; padding: 24px; border-radius: 16px; box-shadow: 0 4px 14px rgba(0,0,0,.08); }
 h1 { font-size: 22px; margin: 0 0 8px; }
-.skeleton { background: #eee; border-radius: 8px; position: relative; overflow: hidden; }
-.skeleton::after { content: ''; position: absolute; inset: 0; transform: translateX(-100%); background: linear-gradient(90deg, transparent, rgba(255,255,255,.5), transparent); animation: shimmer 1.2s infinite; }
-@keyframes shimmer { 100% { transform: translateX(100%); } }
 .row { display: flex; align-items: center; gap: 16px; }
 .price { color: var(--price); font-weight: 700; font-size: 24px; }
 .badge { padding: 2px 8px; border-radius: 999px; background: #f1f5f9; color: #334155; font-size: 12px; }
 .countdown { font-variant-numeric: tabular-nums; }
 footer { margin-top: 20px; color: var(--muted); font-size: 12px; }
-promo-shadow::part(button){ all: unset; display: inline-block; padding: 10px 16px; border-radius: 999px; background: var(--brand-color, #16a34a); color: white; font-weight: 700; cursor: pointer; }
+promo-shadow::part(button){ --ant-primary-color: var(--brand-color, #16a34a); }


### PR DESCRIPTION
## Summary
- add Ant Design dependency and base stylesheet
- swap custom skeletons for Ant Design `<Skeleton>` blocks
- render CTA button with Ant Design `<Button>` inside shadow DOM

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68c022a7b5f48320ac7b84c611a03064