### PR TITLE
feat: add suspense resource for personalized price

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,7 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react'
+import React, { Suspense, useMemo } from 'react'
 import { PersonalizedPrice } from './personalized/PersonalizedPrice'
+import { Skeleton } from './personalized/Skeleton'
+import { PriceErrorBoundary } from './personalized/PriceErrorBoundary'
 import { Countdown } from './personalized/Countdown'
 import './style.css'
 
@@ -59,7 +61,20 @@ export function App({ promoState }: { promoState?: PromoState }) {
       </section>
 
       <section style={{ marginTop: 16 }}>
-        <PersonalizedPrice base={initial.basePrice} />
+        <PriceErrorBoundary>
+          <Suspense
+            fallback={
+              <div>
+                <strong>个性化价格：</strong>
+                <Skeleton width={80} height={16} />
+                <div style={{ marginTop: 6, fontSize: 12, color: '#64748b' }}>
+                  提示：在浏览器控制台运行 <code>localStorage.setItem('logged','1')</code> 再刷新，即可看到会员价生效。
+                </div>
+              </div>
+            }>
+            <PersonalizedPrice base={initial.basePrice} />
+          </Suspense>
+        </PriceErrorBoundary>
       </section>
 
       <footer>

--- a/src/personalized/PersonalizedPrice.tsx
+++ b/src/personalized/PersonalizedPrice.tsx
@@ -1,45 +1,48 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo } from 'react'
+import { createResource } from './createResource'
 
 export function PersonalizedPrice({ base }: { base: number }) {
-  const [price, setPrice] = useState<number | null>(null)
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const resource = useMemo(
+    () =>
+      createResource(async () => {
+        const logged = localStorage.getItem('logged') === '1'
+        const controller = new AbortController()
+        const id = setTimeout(() => controller.abort(), 3000)
+        try {
+          const res = await fetch(`/api/price?base=${base}&logged=${logged ? '1' : '0'}`, {
+            signal: controller.signal
+          })
+          const data = await res.json()
+          if (typeof data.price !== 'number') {
+            throw new Error('请求失败，已回退为 SSR 价格')
+          }
+          return data.price as number
+        } catch (e: any) {
+          if (e.name === 'AbortError') {
+            throw new Error('请求超时，已回退为 SSR 价格')
+          }
+          throw new Error('请求失败，已回退为 SSR 价格')
+        } finally {
+          clearTimeout(id)
+        }
+      }),
+    [base]
+  )
+
+  const price = resource.read()
 
   useEffect(() => {
-    // Simulate "logged-in" state via localStorage flag. Toggle it in DevTools.
-    const logged = localStorage.getItem('logged') === '1'
-
-    const controller = new AbortController()
-    const id = setTimeout(() => controller.abort(), 3000) // timeout safeguard
-
-    setLoading(true)
-    fetch(`/api/price?base=${base}&logged=${logged ? '1' : '0'}`, { signal: controller.signal })
-      .then(r => r.json())
-      .then(d => {
-        setPrice(d.price)
-        // replace SSR price if improved
-        const el = document.getElementById('price-ssr')
-        if (el && typeof d.price === 'number') el.textContent = '¥' + d.price
-        console.log('replace:complete', { success: true })
-      })
-      .catch(e => {
-        if (e.name === 'AbortError') setError('请求超时，已回退为 SSR 价格')
-        else setError('请求失败，已回退为 SSR 价格')
-        console.log('replace:error', { error: e.message })
-      })
-      .finally(() => {
-        clearTimeout(id)
-        setLoading(false)
-      })
-  }, [base])
+    const el = document.getElementById('price-ssr')
+    if (el && typeof price === 'number') {
+      el.textContent = '¥' + price
+      console.log('replace:complete', { success: true })
+    }
+  }, [price])
 
   return (
     <div>
       <strong>个性化价格：</strong>
-      {loading && <span>加载中…</span>}
-      {!loading && error && <span style={{ color: '#b91c1c' }}>{error}</span>}
-      {!loading && !error && price !== null && <span>¥{price}（基于登录状态）</span>}
-      {!loading && !error && price === null && <span>（已回退为 SSR 价格）</span>}
+      <span>¥{price}（基于登录状态）</span>
       <div style={{ marginTop: 6, fontSize: 12, color: '#64748b' }}>
         提示：在浏览器控制台运行 <code>localStorage.setItem('logged','1')</code> 再刷新，即可看到会员价生效。
       </div>

--- a/src/personalized/PriceErrorBoundary.tsx
+++ b/src/personalized/PriceErrorBoundary.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+
+export class PriceErrorBoundary extends React.Component<{ children: React.ReactNode }> {
+  state: { error: Error | null } = { error: null }
+
+  static getDerivedStateFromError(error: Error) {
+    return { error }
+  }
+
+  componentDidCatch(error: Error) {
+    console.log('replace:error', { error: error.message })
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div>
+          <strong>个性化价格：</strong>
+          <span style={{ color: '#b91c1c' }}>{this.state.error.message}</span>
+          <div style={{ marginTop: 6, fontSize: 12, color: '#64748b' }}>
+            提示：在浏览器控制台运行 <code>localStorage.setItem('logged','1')</code> 再刷新，即可看到会员价生效。
+          </div>
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}

--- a/src/personalized/Skeleton.tsx
+++ b/src/personalized/Skeleton.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export function Skeleton({ width, height }: { width?: number | string; height?: number | string }) {
+  return <div className="skeleton" style={{ width, height }} aria-hidden="true"></div>
+}

--- a/src/personalized/createResource.ts
+++ b/src/personalized/createResource.ts
@@ -1,0 +1,21 @@
+export function createResource<T>(fn: () => Promise<T>) {
+  let status: 'pending' | 'success' | 'error' = 'pending'
+  let result: T | Error
+  const suspender = fn().then(
+    r => {
+      status = 'success'
+      result = r
+    },
+    e => {
+      status = 'error'
+      result = e
+    }
+  )
+  return {
+    read(): T {
+      if (status === 'pending') throw suspender
+      if (status === 'error') throw result
+      return result as T
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- fetch personalized price via createResource to enable Suspense
- wrap personalized price with Suspense fallback skeleton and error boundary
- provide utility Skeleton and error boundary components

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c022a8e1648320b8a8f134117174eb